### PR TITLE
Search package by name

### DIFF
--- a/CNPM_ADD_PACKAGE2.cmake
+++ b/CNPM_ADD_PACKAGE2.cmake
@@ -17,7 +17,8 @@ function(CNPM_ADD_PACKAGE)
             "${SHOW_ARGUMENT}"
             SHOW_ARGUMENT
     )
-    IF (NOT DEFINED SEARCH)
+
+    IF (NOT DEFINED SEARCH_NAME)
     foreach(argument ${oneValueArgs})
         if(argument STREQUAL SHOW_ARGUMENT)
             execute_process(
@@ -41,15 +42,17 @@ function(CNPM_ADD_PACKAGE)
     else()
         string(
             TOUPPER
-                "${SEARCH}"
-                SEARCH
+                "${SEARCH_NAME}"
+                SEARCH_NAME
         )
+
         string(
             TOUPPER
                 "${NPM_ARGS_NAME}"
                 PACKAGE_NAME
         )
-        if("${PACKAGE_NAME}" STREQUAL SEARCH) 
+        
+        if("${PACKAGE_NAME}" STREQUAL SEARCH_NAME) 
         execute_process(
             COMMAND
                 ${CMAKE_COMMAND}

--- a/CNPM_ADD_PACKAGE2.cmake
+++ b/CNPM_ADD_PACKAGE2.cmake
@@ -19,26 +19,26 @@ function(CNPM_ADD_PACKAGE)
     )
 
     IF (NOT DEFINED SEARCH_NAME)
-    foreach(argument ${oneValueArgs})
-        if(argument STREQUAL SHOW_ARGUMENT)
-            execute_process(
-                COMMAND
-                    ${CMAKE_COMMAND}
-                    -E
-                    echo_append
-                    "${NPM_ARGS_${SHOW_ARGUMENT}}"
-                WORKING_DIRECTORY
-                    ${CMAKE_CURRENT_LIST_DIR}
-            )
+        foreach(argument ${oneValueArgs})
+            if(argument STREQUAL SHOW_ARGUMENT)
+                execute_process(
+                    COMMAND
+                        ${CMAKE_COMMAND}
+                        -E
+                        echo_append
+                        "${NPM_ARGS_${SHOW_ARGUMENT}}"
+                    WORKING_DIRECTORY
+                        ${CMAKE_CURRENT_LIST_DIR}
+                )
 
-            return()
-        endif()
-    endforeach()
+                return()
+            endif()
+        endforeach()
 
-    message(
-        FATAL_ERROR
-        "Unknown argument name: '${SHOW_ARGUMENT}'"
-    )
+        message(
+            FATAL_ERROR
+            "Unknown argument name: '${SHOW_ARGUMENT}'"
+        )
     else()
         string(
             TOUPPER
@@ -51,19 +51,19 @@ function(CNPM_ADD_PACKAGE)
                 "${NPM_ARGS_NAME}"
                 PACKAGE_NAME
         )
-        
+
         if("${PACKAGE_NAME}" STREQUAL SEARCH_NAME) 
-        execute_process(
-            COMMAND
-                ${CMAKE_COMMAND}
-                    -E
-                    echo_append
-                    "${NPM_ARGS_${SHOW_ARGUMENT}}"
-                    WORKING_DIRECTORY
-                    ${CMAKE_CURRENT_LIST_DIR}
-                )
-            return()
+            execute_process(
+                COMMAND
+                    ${CMAKE_COMMAND}
+                        -E
+                        echo_append
+                        "${NPM_ARGS_${SHOW_ARGUMENT}}"
+                        WORKING_DIRECTORY
+                        ${CMAKE_CURRENT_LIST_DIR}
+                    )
+                return()
+            endif()
         endif()
-    endif()
 endfunction()
 

--- a/CNPM_ADD_PACKAGE2.cmake
+++ b/CNPM_ADD_PACKAGE2.cmake
@@ -17,7 +17,7 @@ function(CNPM_ADD_PACKAGE)
             "${SHOW_ARGUMENT}"
             SHOW_ARGUMENT
     )
-
+    IF (NOT DEFINED SEARCH)
     foreach(argument ${oneValueArgs})
         if(argument STREQUAL SHOW_ARGUMENT)
             execute_process(
@@ -38,5 +38,29 @@ function(CNPM_ADD_PACKAGE)
         FATAL_ERROR
         "Unknown argument name: '${SHOW_ARGUMENT}'"
     )
+    else()
+        string(
+            TOUPPER
+                "${SEARCH}"
+                SEARCH
+        )
+        string(
+            TOUPPER
+                "${NPM_ARGS_NAME}"
+                PACKAGE_NAME
+        )
+        if("${PACKAGE_NAME}" STREQUAL SEARCH) 
+        execute_process(
+            COMMAND
+                ${CMAKE_COMMAND}
+                    -E
+                    echo_append
+                    "${NPM_ARGS_${SHOW_ARGUMENT}}"
+                    WORKING_DIRECTORY
+                    ${CMAKE_CURRENT_LIST_DIR}
+                )
+            return()
+        endif()
+    endif()
 endfunction()
 


### PR DESCRIPTION
If multiple packages were defined in the same file, the arguments of all packages were displayed.
```
cmake -DFILEPATH=packages.cmake  -DSHOW_ARGUMENT=version -P ./cnpm/show_package_component.cmake
9.2.14.5.2.31.80.05.15.1
```
Now it is possible to search for the desired package by name
```
cmake -DFILEPATH=packages.cmake  -DSHOW_ARGUMENT=version  -DSEARCH=qt  -P ./cnpm/show_package_component.cmake
5.15.1
```